### PR TITLE
Adding package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "evispa-timo-jsclipper",
+  "version": "6.1.3",
+  "description": "Boolean operations and offsetting library in Javascript.",
+  "main": "clipper.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/evispa/timo-jsclipper.git"
+  },
+  "keywords": ["clipper", "jsclipper", "javascript-clipper"],
+  "author": "Timo Angus Johnson (http://www.angusj.com)",
+  "license": "BSL-1.0",
+  "bugs": {
+    "url": "https://github.com/evispa/timo-jsclipper/issues"
+  },
+  "homepage": "https://github.com/evispa/timo-jsclipper#readme"
+}


### PR DESCRIPTION
This change allows installing the package through npm - without even adding it to the npmjs.org. I essentially accepted npm init's defaults and adopted everything to match the existing bower.json. The name is slighlty cryptic and if you feel like pushing it to npmjs.org... jsclipper is not yet taken.
